### PR TITLE
fix: github actions wrong node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,11 @@ jobs:
   test-jest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Setup Node
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
       - name: Install modules
         run: yarn
       - name: Run tests


### PR DESCRIPTION
<!-- Thanks for sending a pr to comarev :D -->
<!-- what github issue is this PR for, if any? -->



<!-- if this pr is not closing the issue, but it is related somehow -->



#### What?

- Github Actions setup now gets the node version from the project

#### Why?

- Github Actions were failing because it was using the wrong node version
![image](https://user-images.githubusercontent.com/27422266/161777746-85b1f7bd-1cf5-4b42-9e06-971d88ff4b1e.png)

#### How to test it?

- Github Actions should not show errors
